### PR TITLE
fix bug: func RouterFromContext return nil router

### DIFF
--- a/core/sing/node.go
+++ b/core/sing/node.go
@@ -1,7 +1,6 @@
 package sing
 
 import (
-	"context"
 	"crypto/rand"
 	"encoding/base64"
 	"fmt"
@@ -215,8 +214,9 @@ func (b *Box) AddNode(tag string, info *panel.NodeInfo, config *conf.Options) er
 	if err != nil {
 		return err
 	}
+
 	in, err := inbound.New(
-		context.Background(),
+		b.ctx,
 		b.router,
 		b.logFactory.NewLogger(F.ToString("inbound/", c.Type, "[", tag, "]")),
 		c,

--- a/core/sing/sing.go
+++ b/core/sing/sing.go
@@ -31,6 +31,7 @@ type DNSConfig struct {
 }
 
 type Box struct {
+        ctx        context.Context
 	createdAt  time.Time
 	router     adapter.Router
 	inbounds   map[string]adapter.Inbound
@@ -169,6 +170,7 @@ func New(c *conf.CoreConfig) (vCore.Core, error) {
 	}
 	router.SetClashServer(server)
 	return &Box{
+                ctx:        ctx,
 		router:     router,
 		inbounds:   inMap,
 		outbounds:  outbounds,


### PR DESCRIPTION
inbound参数使用context.Background()导致从上下文获取不到router